### PR TITLE
Add example to README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+example.out

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ or:
 ```
 
 
-# Examples
+# Example:
 
 To show how `dss` works we will run a few commands to show an example file with
 consecutive blank lines and then remove them (redirecting to an out file) and

--- a/README.md
+++ b/README.md
@@ -27,6 +27,80 @@ or:
 ```
 
 
+# Examples
+
+To show how `dss` works we will run a few commands to show an example file with
+consecutive blank lines and then remove them (redirecting to an out file) and
+then update (also with `sed(1)`) to correct the text in the lines before we then
+show the updated file. The reason the text has to be updated in the output file
+is because we want to show how the number of lines is changed due to consecutive
+blank lines.
+
+## First show `example.txt`:
+
+```sh
+   cat example.txt
+```
+
+You should see:
+
+```sh
+    This is the first line.
+
+
+
+    This is the fifth line.
+```
+
+## Second run `dss` on the file, writing the output to `example.out`
+
+```sh
+    dss < example.txt > example.out
+```
+
+Here you should see no output so we will show what `example.out` looks like
+after `dss` processes it, below.
+
+## Third, show `example.out`:
+
+```sh
+    cat example.out
+```
+
+You should see:
+
+```
+    This is the first line.
+
+    This is the fifth line.
+```
+
+## Fourth, fix the text in `example.out`:
+
+As can be seen, `dss` removed the consecutive lines so the text describing the
+(now third) line is incorrect. Let's fix it:
+
+```sh
+    sed -i'' 's/fifth/third/g' example.out
+```
+
+## Finally show the contents of `example.out`
+
+```sh
+    cat example.out
+```
+
+This will show the correctly updated `example.out`:
+
+```
+    This is the first line.
+
+    This is the third line.
+```
+
+Of course you could change the order of commands but this shows how it works
+well enough.
+
 # History:
 
 The `dss.sed` file and the `dss` shell script dates back

--- a/example.txt
+++ b/example.txt
@@ -1,0 +1,5 @@
+This is the first line.
+
+
+
+This is the fifth line.


### PR DESCRIPTION
For this commit a new file example.txt was added with the text:

<pre>
    This is the first line.



    This is the fifth line.
</pre>

The example shows the contents of this file (with cat) and then it feeds to dss the file, redirecting the output to example.out. Then example.out is shown which obviously has incorrect text (fifth will be on the third line) so we use sed again (with -i'' [0]) to fix the text in example.out Finally we show the corrected file. Of course one can use a more advanced command (or commands) but this shows the original state and how the script works.

.gitignore added with example.out as this should not be in git.

[0] We use -i'' and not -i because not all implementations of sed allow the -i option without an extension but an empty string is allowed in these implementation (or at least all I have seen). The empty string is, as far as I am aware, a GNU extension; in BSD it is not supported for instance (macOS does not support it and iirc from ages past SunOS/Solaris versions do not support it either - I don't recall FreeBSD but I doubt it supports it unless you install the GNU sed and have it in front of the rest of your path).